### PR TITLE
feat: add local message storage for user prompts in online and offlin…

### DIFF
--- a/src/db/mutations.ts
+++ b/src/db/mutations.ts
@@ -1,0 +1,53 @@
+import type { Id } from "@/convex/_generated/dataModel";
+
+import { localDb } from "@/db/dexie";
+import { DEFAULT_THREAD_TITLE } from "@/lib/constants";
+
+interface LocalThreadParams {
+  title?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export async function createLocalThread({
+  title = DEFAULT_THREAD_TITLE,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+}: LocalThreadParams = {}) {
+  await localDb.threads.add({
+    _id: crypto.randomUUID() as Id<"threads">,
+    _creationTime: createdAt.getTime(),
+    title,
+    userId: undefined,
+    userProvidedId: crypto.randomUUID() as Id<"threads">,
+    createdAt: createdAt.toISOString(),
+    updatedAt: updatedAt.toISOString(),
+  });
+}
+
+interface LocalMessageParams {
+  content: string;
+  threadId: string;
+  version?: number;
+  createdAt?: Date;
+}
+
+export async function createLocalMessage({
+  content,
+  threadId,
+  version = 1,
+  createdAt = new Date(),
+}: LocalMessageParams) {
+  await localDb.messages.add({
+    _id: crypto.randomUUID() as Id<"messages">,
+    _creationTime: createdAt.getTime(),
+    role: "user",
+    content,
+    userId: undefined,
+    userProvidedId: crypto.randomUUID() as Id<"messages">,
+    threadId: threadId as Id<"threads">,
+    userProvidedThreadId: threadId,
+    version,
+    createdAt: createdAt.toISOString(),
+  });
+};

--- a/src/stores/prompt-store.ts
+++ b/src/stores/prompt-store.ts
@@ -1,11 +1,10 @@
 import type { ReactMutation } from "convex/react";
 import type { FunctionReference } from "convex/server";
-import type { Id } from "@/convex/_generated/dataModel";
 
 import { toast } from "sonner";
 import { create } from "zustand";
 
-import { localDb } from "@/db/dexie";
+import { createLocalMessage, createLocalThread } from "@/db/mutations";
 import { routes } from "@/frontend/routes";
 import { DEFAULT_THREAD_TITLE } from "@/lib/constants";
 import { createMessageSchema } from "@/lib/schemas";
@@ -61,28 +60,16 @@ export const usePromptStore = create<PromptStore>((set, get) => ({
           });
 
           if (!isAuthenticated) {
-            await localDb.threads.add({
-              _id: crypto.randomUUID() as Id<"threads">,
-              _creationTime: createdAt.getTime(),
-              title: DEFAULT_THREAD_TITLE,
-              userId: undefined,
-              userProvidedId: threadId,
-              createdAt: createdAt.toISOString(),
-              updatedAt: createdAt.toISOString(),
+            await createLocalThread({
+              createdAt,
+              updatedAt: createdAt,
             });
           }
 
-          await localDb.messages.add({
-            _id: crypto.randomUUID() as Id<"messages">,
-            _creationTime: createdAt.getTime(),
-            role: "user",
+          await createLocalMessage({
             content: prompt,
-            userId: undefined,
-            threadId: threadId as Id<"threads">,
-            userProvidedThreadId: threadId,
-            userProvidedId: crypto.randomUUID() as Id<"messages">,
-            version: 1,
-            createdAt: createdAt.toISOString(),
+            threadId,
+            createdAt,
           });
 
           // TODO: Send prompt to backend for processing
@@ -108,31 +95,19 @@ export const usePromptStore = create<PromptStore>((set, get) => ({
       }
       else {
         try {
-          await localDb.threads.add({
-            _id: crypto.randomUUID() as Id<"threads">,
-            _creationTime: createdAt.getTime(),
-            title: DEFAULT_THREAD_TITLE,
-            userId: undefined,
-            userProvidedId: threadId,
-            createdAt: createdAt.toISOString(),
-            updatedAt: createdAt.toISOString(),
+          await createLocalThread({
+            createdAt,
+            updatedAt: createdAt,
           });
 
           toast.success("Thread saved locally", {
             description: "AI response will be available when you are back online.",
           });
 
-          await localDb.messages.add({
-            _id: crypto.randomUUID() as Id<"messages">,
-            _creationTime: createdAt.getTime(),
-            role: "user",
+          await createLocalMessage({
             content: prompt,
-            userId: undefined,
-            threadId: threadId as Id<"threads">,
-            userProvidedThreadId: threadId,
-            userProvidedId: crypto.randomUUID() as Id<"messages">,
-            version: 1,
-            createdAt: createdAt.toISOString(),
+            threadId,
+            createdAt,
           });
 
           clearPrompt();


### PR DESCRIPTION
This pull request introduces changes to the `src/stores/prompt-store.ts` file to ensure that user prompts are saved locally in the `messages` table of `localDb`. This enhancement supports offline functionality by persisting user-generated prompts even when the backend is unavailable.

### Offline prompt persistence:

* Added logic to save user prompts to the `messages` table in `localDb` with attributes such as `_id`, `_creationTime`, `role`, `content`, `threadId`, and `createdAt`. This ensures prompts are stored locally for offline use.