### PR TITLE
chore: add mcp.json configuration for context7 server

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,13 @@
+{
+  "servers": {
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ]
+    }
+  },
+  "inputs": []
+}


### PR DESCRIPTION
This pull request introduces a configuration file for Visual Studio Code to set up a new `context7` server using the `@upstash/context7-mcp` package. 

* [`.vscode/mcp.json`](diffhunk://#diff-756c99ad6a15758981c15d6ba32a2d83391908e8e021f0399e9d34339dc4eadaR1-R13): Added a new configuration to define a `context7` server of type `stdio`, specifying the `npx` command with arguments to use the latest version of the `@upstash/context7-mcp` package.