### PR TITLE
refactor: reorganize CI workflow jobs for better clarity and structure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
       - main
 
 jobs:
-  lint:
+  setup:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,11 +23,32 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+  install:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Typecheck
-        run: pnpm typecheck
+  lint:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Format & Lint
         run: pnpm lint:fix
+
+  typecheck:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Typecheck
+        run: pnpm typecheck


### PR DESCRIPTION
This pull request refactors the CI workflow configuration in `.github/workflows/ci.yaml` to improve modularity and clarity by splitting the workflow into separate jobs for setup, dependency installation, linting, and type checking.

### Workflow refactoring:

* Renamed the `lint` job to `setup` and created a dedicated job for setting up the environment.
* Added a new `install` job to handle dependency installation, with a dependency on the `setup` job.
* Split the linting and type-checking steps into separate `lint` and `typecheck` jobs for better job isolation, each depending on the `install` job.